### PR TITLE
Obamenu fix for empty categories

### DIFF
--- a/debian/obamenu
+++ b/debian/obamenu
@@ -143,7 +143,7 @@ def process_dtfile(dtf,  catDict):  # process this file & extract relevant info
 				continue
 			this.addType(eqi[1])
 		elif eqi[0] == "Categories":
-			if eqi[1][-1] == ';':
+			if eqi[1] and eqi[1][-1] == ';':
 				eqi[1] = eqi[1][0:-1]
 			cats = []
 			# DEBUG 


### PR DESCRIPTION
Added check for value in eqi[1] before attempting to check for potentially non-existent last character.