### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ openbox (3.6.1-10) UNRELEASED; urgency=medium
 
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
+  * Fix day-of-week for changelog entries 3.5.0-2, 3.5.0-1, 2.0.0-1.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 26 Apr 2020 15:33:13 +0000
 
@@ -447,7 +448,7 @@ openbox (3.5.0-2) unstable; urgency=low
     - remove debian-menu.xml from rc.xml and only load the file from
       /var/lib/openbox to prevent confusing errors in xsessions-errors.
 
- -- Nico Golde <nion@debian.org>  Sun, 31 Oct 2011 23:41:20 +0200
+ -- Nico Golde <nion@debian.org>  Mon, 31 Oct 2011 23:41:20 +0200
 
 openbox (3.5.0-1) unstable; urgency=low
 
@@ -482,7 +483,7 @@ openbox (3.5.0-1) unstable; urgency=low
   * debian/openbox.xsession:
     - Removed. Openbox now ships it by default.
 
- -- Nico Golde <nion@debian.org>  Sun, 03 Oct 2011 22:59:30 +0200
+ -- Nico Golde <nion@debian.org>  Mon, 03 Oct 2011 22:59:30 +0200
 
 openbox (3.4.11.2-2) unstable; urgency=low
 
@@ -1164,7 +1165,7 @@ openbox (2.0.0-1) unstable; urgency=low
 
   * Initial full release from CVS.
 
- -- Kyle McMartin <kyle@debian.org>  Thu, 16 Aug 2002 20:33:10 -0400
+ -- Kyle McMartin <kyle@debian.org>  Fri, 16 Aug 2002 20:33:10 -0400
 
 openbox (0.20020811-1) unstable; urgency=low
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+openbox (3.6.1-10) UNRELEASED; urgency=medium
+
+  * debian/copyright: use spaces rather than tabs to start continuation
+    lines.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 26 Apr 2020 15:33:13 +0000
+
 openbox (3.6.1-9) unstable; urgency=medium
 
   * Switch to python3. (Closes: #887122 #886716) (LP: #1816473)

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,16 +5,16 @@ Source: http://openbox.org/wiki/Openbox:Download
 
 Files: *
 Copyright: 2003, Ben Jansens 
-	   2003, Derek Foreman <manmower@openbox.org>
+           2003, Derek Foreman <manmower@openbox.org>
            2006-2011, Mikael Magnusson <mikachu@comhem.se>
            2003-2011, Dana Jansens <danakj@orodu.net>
 License: GPL-2+
 
 Files: debian/*
 Copyright: 2002, Kyle McMartin <kyle@debian.org>
-	   2003-2004, Tore Anderson <tore@debian.org>
-	   2007-2009, Nico Golde <nion@debian.org>, Anibal Avelar (Fixxxer) <aavelar@cofradia.org>
-	   2013-2020, Mateusz Łukasik <mati75@linuxmint.pl>
+           2003-2004, Tore Anderson <tore@debian.org>
+           2007-2009, Nico Golde <nion@debian.org>, Anibal Avelar (Fixxxer) <aavelar@cofradia.org>
+           2013-2020, Mateusz Łukasik <mati75@linuxmint.pl>
 License: BSD-3-clause
  These scripts are placed under the BSD license:
  Copyright (c) The Regents of the University of California.


### PR DESCRIPTION
Fix some issues reported by lintian
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text.html))
* Fix day-of-week for changelog entries 3.5.0-2, 3.5.0-1, 2.0.0-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbox/75d81fa7-f0b3-4b93-8f89-d31b90a999d4.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/75d81fa7-f0b3-4b93-8f89-d31b90a999d4/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/75d81fa7-f0b3-4b93-8f89-d31b90a999d4/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/75d81fa7-f0b3-4b93-8f89-d31b90a999d4/diffoscope)).
