### PR TITLE
When running with > 2 screens, avoid calling XQueryPointer() in an infinite loop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,13 @@
 openbox (3.6.1-10) UNRELEASED; urgency=medium
 
+  [ Debian Janitor ]
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
   * Fix day-of-week for changelog entries 3.5.0-2, 3.5.0-1, 2.0.0-1.
+
+  [ dann frazier ]
+  * When running with > 2 screens, avoid calling XQueryPointer() in an
+    infinite loop. (Closes: #983882)
 
  -- Debian Janitor <janitor@jelmer.uk>  Sun, 26 Apr 2020 15:33:13 +0000
 

--- a/debian/patches/Fix-collision-between-iterator-and-throw-away-argume.patch
+++ b/debian/patches/Fix-collision-between-iterator-and-throw-away-argume.patch
@@ -1,0 +1,38 @@
+From: Alex Goins <agoins@nvidia.com>
+Date: Thu, 18 Feb 2021 21:25:22 -0600
+Subject: [PATCH] Fix collision between iterator and throw-away argument to
+ XQueryPointer()
+
+Without this, Openbox is unstable on any setup with more than 2 X screens, as
+the collision can make the loop infinitely call XQueryPointer() on X screen 1.
+
+Bug-Debian: https://bugs.debian.org/983882
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1917516
+Origin: https://github.com/AlexGoinsNV/openbox-multiXscreen-bugfix/commit/2635c87d160aa5f6f9e91e290678e99111788d57
+Last-Updated: 2021-03-02
+
+Index: openbox-debian/openbox/screen.c
+===================================================================
+--- openbox-debian.orig/openbox/screen.c
++++ openbox-debian/openbox/screen.c
+@@ -1908,16 +1908,16 @@ guint screen_monitor_pointer()
+ gboolean screen_pointer_pos(gint *x, gint *y)
+ {
+     Window w;
+-    gint i;
++    gint i, scrnindex;
+     guint u;
+     gboolean ret;
+ 
+     ret = !!XQueryPointer(obt_display, obt_root(ob_screen),
+                           &w, &w, x, y, &i, &i, &u);
+     if (!ret) {
+-        for (i = 0; i < ScreenCount(obt_display); ++i)
+-            if (i != ob_screen)
+-                if (XQueryPointer(obt_display, obt_root(i),
++        for (scrnindex = 0; scrnindex < ScreenCount(obt_display); ++scrnindex)
++            if (scrnindex != ob_screen)
++                if (XQueryPointer(obt_display, obt_root(scrnindex),
+                                   &w, &w, x, y, &i, &i, &u))
+                     break;
+     }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -24,3 +24,4 @@ adapt-to-gsd-324.patch
 python3.patch
 Allow-256x256-window-icon-size-for-HiDPI-displays.patch
 Add-class-hint-to-focus-cycle-popup.patch
+Fix-collision-between-iterator-and-throw-away-argume.patch


### PR DESCRIPTION
…finite loop. (Closes: #983882)