### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 openbox (3.6.1-11) UNRELEASED; urgency=medium
 
   * Remove 1 obsolete maintscript entry.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 13:36:48 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openbox (3.6.1-11) UNRELEASED; urgency=medium
+
+  * Remove 1 obsolete maintscript entry.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 13:36:48 -0000
+
 openbox (3.6.1-10) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/openbox.maintscript
+++ b/debian/openbox.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/xdg/openbox/autostart.sh 3.5.0-1

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_LDFLAGS_MAINT_APPEND=-Wl,--as-needed -Wl,-O1 -Wl,-z,defs
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Remove 1 obsolete maintscript entry.

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbox/918f5aea-96bb-415d-830e-e678fabe2c37.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/918f5aea-96bb-415d-830e-e678fabe2c37/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/918f5aea-96bb-415d-830e-e678fabe2c37/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/918f5aea-96bb-415d-830e-e678fabe2c37/diffoscope)).
