### PR TITLE
Set upstream metadata fields: Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,6 +11,9 @@ openbox (3.6.1-11) UNRELEASED; urgency=medium
     + Add patch for fix openbox invokes imlib_free_image when no image
     is loaded (Closes: #1007147)
 
+  [ Debian Janitor ]
+  * Set upstream metadata fields: Repository-Browse.
+
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 13:36:48 -0000
 
 openbox (3.6.1-10) unstable; urgency=medium

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://github.com/danakj/openbox


### PR DESCRIPTION

Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbox/dbd17dfe-574e-4376-b28d-0ec38c4f1385.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/dbd17dfe-574e-4376-b28d-0ec38c4f1385/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/dbd17dfe-574e-4376-b28d-0ec38c4f1385/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/dbd17dfe-574e-4376-b28d-0ec38c4f1385/diffoscope)).
