### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,6 +11,16 @@ openbox (3.6.1-11) UNRELEASED; urgency=medium
     + Add patch for fix openbox invokes imlib_free_image when no image
     is loaded (Closes: #1007147)
 
+  [ Debian Janitor ]
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on automake and libxml2-dev.
+    + gnome-panel-control: Drop versioned constraint on openbox in Replaces.
+    + gnome-panel-control: Drop versioned constraint on openbox in Breaks.
+    + openbox-gnome-session: Drop versioned constraint on openbox in Replaces.
+    + openbox-gnome-session: Drop versioned constraint on openbox in Breaks.
+    + openbox-kde-session: Drop versioned constraint on openbox in Replaces.
+    + openbox-kde-session: Drop versioned constraint on openbox in Breaks.
+
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Feb 2022 13:36:48 -0000
 
 openbox (3.6.1-10) unstable; urgency=medium

--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,9 @@ Section: x11
 Priority: optional
 Maintainer: Mateusz Łukasik <mati75@linuxmint.pl>
 Build-Depends: debhelper-compat (= 13), gettext, libstartup-notification0-dev,
- libxrender-dev, pkg-config, libglib2.0-dev, libxml2-dev (>= 2.6.0), perl,
+ libxrender-dev, pkg-config, libglib2.0-dev, libxml2-dev, perl,
  libxt-dev, libxinerama-dev, libxrandr-dev, libpango1.0-dev, libx11-dev,
- autoconf, automake (>= 1:1.11), libimlib2-dev, libxcursor-dev,
+ autoconf, automake, libimlib2-dev, libxcursor-dev,
  autopoint, librsvg2-dev, libxi-dev
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
@@ -121,8 +121,6 @@ Description: development files for the openbox window manager
 Package: gnome-panel-control
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Replaces: openbox (<< 3.4.11.2)
-Breaks: openbox (<< 3.4.11.2)
 Description: command line utility to invoke GNOME panel run dialog/menu
  gnome-panel-control can be used to invoke the GNOME panel run or main
  menu from the command line. This is originally a helper utility of openbox
@@ -133,8 +131,6 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, openbox (>= ${source:Version}),
  gnome-session-bin, x11-utils
 Enhances: gnome-session
-Replaces: openbox (<< 3.5.2-5)
-Breaks: openbox (<< 3.5.2-5)
 Description: command line utility to run Openbox as GNOME session
  openbox-gnome-session can provide GNOME session with openbox as
  a default window manager. It can replace the original window manager
@@ -145,8 +141,6 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, openbox (>= ${source:Version}),
  x11-utils, plasma-workspace
 Enhances: kde-workspace
-Replaces: openbox (<< 3.5.2-5)
-Breaks: openbox (<< 3.5.2-5)
 Description: command line utility to run Openbox as KDE SC session
  openbox-kde-session can provide KDE SC session with openbox as
  a default window manager. Can replace the original window manager


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/openbox/6095b77b-3602-4206-b233-1936467704e1.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package gnome-panel-control: lines which differ (wdiff format)
* [-Breaks: openbox (<< 3.4.11.2)-]
* [-Replaces: openbox (<< 3.4.11.2)-]

No differences were encountered between the control files of package \*\*gnome-panel-control-dbgsym\*\*

No differences were encountered between the control files of package \*\*libobrender32v5\*\*

No differences were encountered between the control files of package \*\*libobrender32v5-dbgsym\*\*

No differences were encountered between the control files of package \*\*libobt2v5\*\*

No differences were encountered between the control files of package \*\*libobt2v5-dbgsym\*\*

No differences were encountered between the control files of package \*\*openbox\*\*

No differences were encountered between the control files of package \*\*openbox-dbgsym\*\*

No differences were encountered between the control files of package \*\*openbox-dev\*\*
### Control files of package openbox-gnome-session: lines which differ (wdiff format)
* [-Breaks: openbox (<< 3.5.2-5)-]
* [-Replaces: openbox (<< 3.5.2-5)-]
### Control files of package openbox-kde-session: lines which differ (wdiff format)
* [-Breaks: openbox (<< 3.5.2-5)-]
* [-Replaces: openbox (<< 3.5.2-5)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6095b77b-3602-4206-b233-1936467704e1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6095b77b-3602-4206-b233-1936467704e1/diffoscope)).
