### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,6 +53,7 @@ Architecture: any
 Conflicts: libobt2
 Replaces: libobt2
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: parsing library for openbox
  Openbox works with your applications, and makes your desktop easier to manage.
  This is because the approach to its development was the opposite of what seems


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/openbox/aff278d7-23d8-45f7-88fa-d21990bff28f.



These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/aff278d7-23d8-45f7-88fa-d21990bff28f/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/aff278d7-23d8-45f7-88fa-d21990bff28f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/aff278d7-23d8-45f7-88fa-d21990bff28f/diffoscope)).
