### PR TITLE
make python3 recommended dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,8 +17,8 @@ Package: openbox
 Architecture: any
 Provides: x-window-manager, x-session-manager
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3
-Recommends: obconf | obconf-qt, scrot
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Recommends: python3, obconf | obconf-qt, scrot
 Suggests: fonts-dejavu, libxml2-dev, tint2,
  openbox-gnome-session (= ${binary:Version}), openbox-kde-session (= ${binary:Version})
 Breaks: openbox-theme-breeze (<< 1.0)


### PR DESCRIPTION
Thanks Mateusz  for maintaining packaging for Debian.

I hope to find a way for the openbox Debian package to not have a hard dependency on python3 and switch that to either an optional (suggested) dependency instead or introduce a new package for the python3 dependent part and factor it out from the core openbox package.

Some other distro's packages - e.g. arch makes python3 an optional dependency - https://gitlab.archlinux.org/archlinux/packaging/packages/openbox/-/blob/main/PKGBUILD#L19